### PR TITLE
Rack 3.x support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
           - 4.8
           - latest
         ruby-version:
-          - 2.3
           - 2.4
           - 2.5
           - 2.6
@@ -34,11 +33,6 @@ jobs:
           - 3.2
           - head
         exclude:
-          - { ruby-version: 2.3, redis-version: 4.5 }
-          - { ruby-version: 2.3, redis-version: 4.6 }
-          - { ruby-version: 2.3, redis-version: 4.7 }
-          - { ruby-version: 2.3, redis-version: 4.8 }
-          - { ruby-version: 2.3, redis-version: latest }
           - { ruby-version: 2.4, redis-version: latest }
     env:
       REDIS_VERSION: "${{ matrix.redis-version }}"

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,16 @@ end
 gem "json"
 gem "minitest", "~> 5.11"
 gem "mocha", "~> 2.0", require: false
+
+ruby_version = Gem::Version.new(RUBY_VERSION)
+if ruby_version >= Gem::Version.new("2.4") && ruby_version < Gem::Version.new("2.6")
+  gem "rack", "~> 1"
+elsif ruby_version >= Gem::Version.new("2.6") && ruby_version < Gem::Version.new("2.7")
+  gem "rack", "~> 2"
+else
+  gem "rack"
+end
+
 gem "rack-test", "~> 2.0"
 gem "rake"
 gem "rubocop", "~> 0.80"

--- a/README.markdown
+++ b/README.markdown
@@ -39,7 +39,7 @@ The Resque frontend tells you what workers are doing, what workers are
 not doing, what queues you're using, what's in those queues, provides
 general usage stats, and helps you track failures.
 
-Resque now supports Ruby 2.3.0 and above.
+Resque now supports Ruby 2.4.0 and above.
 We will also only be supporting Redis 3.0 and above going forward.
 
 ### Note on the future of Resque

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -3,6 +3,7 @@ require 'logger'
 require 'optparse'
 require 'fileutils'
 require 'rack'
+require 'rackup'
 require 'resque/server'
 
 # only used with `bin/resque-web`
@@ -30,7 +31,7 @@ module Resque
 
       @args = load_options(runtime_args)
 
-      @rack_handler = (s = options[:rack_handler]) ? Rack::Handler.get(s) : setup_rack_handler
+      @rack_handler = (s = options[:rack_handler]) ? self.class.get_rackup_or_rack_handler.get(s) : setup_rack_handler
 
       case option_parser.command
       when :help
@@ -270,6 +271,10 @@ module Resque
       self.class.logger
     end
 
+    def self.get_rackup_or_rack_handler
+      defined?(::Rackup::Handler) ? ::Rackup::Handler : ::Rack::Handler
+    end
+
   private
     def setup_rack_handler
       # First try to set Rack handler via a special hook we honor
@@ -284,7 +289,7 @@ module Resque
           handler = nil
           @app.server.each do |server|
             begin
-              handler = Rack::Handler.get(server)
+              handler = self.class.get_rackup_or_rack_handler.get(server)
               break
             rescue LoadError, NameError
               next
@@ -296,12 +301,13 @@ module Resque
 
         # :server might be set explicitly to a single option like "mongrel"
         else
-          Rack::Handler.get(@app.server)
+          self.class.get_rackup_or_rack_handler.get(@app.server)
         end
 
       # If all else fails, we'll use Thin
       else
-        JRUBY ? Rack::Handler::WEBrick : Rack::Handler::Thin
+        rack_server = JRUBY ? 'webrick' : 'puma'
+        self.class.get_rackup_or_rack_handler.get(rack_server)
       end
     end
 

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -304,7 +304,7 @@ module Resque
           self.class.get_rackup_or_rack_handler.get(@app.server)
         end
 
-      # If all else fails, we'll use Thin
+      # If all else fails, we'll use Puma
       else
         rack_server = JRUBY ? 'webrick' : 'puma'
         self.class.get_rackup_or_rack_handler.get(rack_server)

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -44,7 +44,8 @@ Gem::Specification.new do |s|
     * A Sinatra app for monitoring queues, jobs, and workers.
 description
 
-  s.add_development_dependency "thin"
+  s.add_development_dependency "puma"
+  s.add_development_dependency "rackup"
   s.add_development_dependency "webrick"
 
   s.metadata['changelog_uri'] = 'https://github.com/resque/resque/blob/master/HISTORY.md'

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.4.0"
 
   s.add_dependency "redis-namespace", "~> 1.6"
   s.add_dependency "sinatra", ">= 0.9.2"

--- a/test/resque-web_runner_test.rb
+++ b/test/resque-web_runner_test.rb
@@ -4,10 +4,15 @@ require 'resque/server'
 require 'resque/web_runner'
 
 describe 'Resque::WebRunner' do
+  def get_rackup_or_rack_handler
+    Resque::WebRunner.get_rackup_or_rack_handler
+  end
+
   def web_runner(*args)
     Resque::WebRunner.any_instance.stubs(:daemonize!).once
 
-    Resque::JRUBY ? Rack::Handler::WEBrick.stubs(:run).once : Rack::Handler::Thin.stubs(:run).once
+    rack_server = Resque::JRUBY ? 'webrick' : 'puma'
+    get_rackup_or_rack_handler.get(rack_server).stubs(:run).once
 
     @runner = Resque::WebRunner.new(*args)
   end
@@ -68,13 +73,13 @@ describe 'Resque::WebRunner' do
     describe 'with a sinatra app using an explicit server setting' do
       def web_runner(*args)
         Resque::WebRunner.any_instance.stubs(:daemonize!).once
-        Rack::Handler::WEBrick.stubs(:run).once
+        get_rackup_or_rack_handler::WEBrick.stubs(:run).once
         @runner = Resque::WebRunner.new(*args)
       end
 
       before do
         Resque::Server.set :server, "webrick"
-        Rack::Handler::WEBrick.stubs(:run)
+        get_rackup_or_rack_handler::WEBrick.stubs(:run)
         web_runner("route","--debug", skip_launch: true, sessions: true)
       end
       after do
@@ -82,20 +87,20 @@ describe 'Resque::WebRunner' do
       end
 
       it 'sets the rack handler automatically' do
-        assert_equal @runner.rack_handler, Rack::Handler::WEBrick
+        assert_equal @runner.rack_handler, get_rackup_or_rack_handler::WEBrick
       end
     end
 
     describe 'with a sinatra app without an explicit server setting' do
       def web_runner(*args)
         Resque::WebRunner.any_instance.stubs(:daemonize!).once
-        Rack::Handler::WEBrick.stubs(:run).once
+        get_rackup_or_rack_handler::WEBrick.stubs(:run).once
         @runner = Resque::WebRunner.new(*args)
       end
 
       before do
         Resque::Server.set :server, ["invalid", "webrick", "thin"]
-        Rack::Handler::WEBrick.stubs(:run)
+        get_rackup_or_rack_handler::WEBrick.stubs(:run)
         web_runner("route", "--debug", skip_launch: true, sessions: true)
       end
 
@@ -104,7 +109,7 @@ describe 'Resque::WebRunner' do
       end
 
       it 'sets the first valid rack handler' do
-        assert_equal @runner.rack_handler, Rack::Handler::WEBrick
+        assert_equal @runner.rack_handler, get_rackup_or_rack_handler::WEBrick
       end
     end
 
@@ -130,11 +135,11 @@ describe 'Resque::WebRunner' do
         web_runner(skip_launch: true, sessions: true)
       end
 
-      it "sets default rack handler to thin when in ruby and WEBrick when in jruby" do
+      it "sets default rack handler to puma when in ruby and WEBrick when in jruby" do
         if Resque::JRUBY
-          assert_equal @runner.rack_handler, Rack::Handler::WEBrick
+          assert_equal @runner.rack_handler, get_rackup_or_rack_handler::WEBrick
         else
-          assert_equal @runner.rack_handler, Rack::Handler::Thin
+          assert_equal @runner.rack_handler, get_rackup_or_rack_handler::Puma
         end
       end
     end

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -9,6 +9,10 @@ describe "Resque web" do
     Resque::Server.new
   end
 
+  def default_host
+    'localhost'
+  end
+
   # Root path test
   describe "on GET to /" do
     before { get "/" }


### PR DESCRIPTION
* swich dev dependency from `thin` to `puma` as `thin` is not rack 3.x compatible
* added `rackup` dependency
* added code to work with both `rack 2.x` and `rack 3.x` versions